### PR TITLE
OpenWeather API integration

### DIFF
--- a/go/client/client.go
+++ b/go/client/client.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -29,4 +31,17 @@ func NewAPIClient() *APIClient {
 		Url:    url,
 		ApiKey: apiKey,
 	}
+}
+func (c *APIClient) FetchForecast(city string) ([]byte, error) {
+	reqURL := fmt.Sprintf("%s?q=%s&appid=%s", c.Url, city, c.ApiKey)
+	resp, err := c.Client.Get(reqURL)
+	if err != nil {
+		return nil, fmt.Errorf("Fetch error: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Fetch error: %w", err)
+	}
+	return body, nil
 }

--- a/go/client/client.go
+++ b/go/client/client.go
@@ -37,13 +37,12 @@ func (c *APIClient) FetchForecast(city string) ([]byte, error) {
 	reqURL := fmt.Sprintf("%s?q=%s&appid=%s", c.Url, city, c.ApiKey)
 	fmt.Println(reqURL)
 	resp, err := c.Client.Get(reqURL)
-	fmt.Println(resp)
 	if err != nil {
 		return nil, fmt.Errorf("Fetch error: %w", err)
 	}
+	fmt.Println("response status:", resp.Status)
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
-	fmt.Println(body)
 	if err != nil {
 		return nil, fmt.Errorf("Fetch error: %w", err)
 	}

--- a/go/client/client.go
+++ b/go/client/client.go
@@ -33,13 +33,17 @@ func NewAPIClient() *APIClient {
 	}
 }
 func (c *APIClient) FetchForecast(city string) ([]byte, error) {
+	fmt.Println("Fetching forecast")
 	reqURL := fmt.Sprintf("%s?q=%s&appid=%s", c.Url, city, c.ApiKey)
+	fmt.Println(reqURL)
 	resp, err := c.Client.Get(reqURL)
+	fmt.Println(resp)
 	if err != nil {
 		return nil, fmt.Errorf("Fetch error: %w", err)
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
+	fmt.Println(body)
 	if err != nil {
 		return nil, fmt.Errorf("Fetch error: %w", err)
 	}

--- a/go/client/client.go
+++ b/go/client/client.go
@@ -1,4 +1,4 @@
-package models
+package client
 
 import (
 	"log"
@@ -10,9 +10,9 @@ import (
 )
 
 type APIClient struct {
-	client *http.Client
-	url    string
-	apiKey string
+	Client *http.Client
+	Url    string
+	ApiKey string
 }
 
 func NewAPIClient() *APIClient {
@@ -23,10 +23,10 @@ func NewAPIClient() *APIClient {
 		log.Fatal("API_URL or API_KEY not set")
 	}
 	return &APIClient{
-		client: &http.Client{
+		Client: &http.Client{
 			Timeout: 10 * time.Second,
 		},
-		url:    url,
-		apiKey: apiKey,
+		Url:    url,
+		ApiKey: apiKey,
 	}
 }

--- a/go/handlers/weather.go
+++ b/go/handlers/weather.go
@@ -1,13 +1,20 @@
 package handlers
 
 import (
+	"DVK-Project/client"
 	"DVK-Project/models"
 	"encoding/json"
+	"fmt"
 	"html/template"
 	"net/http"
 )
 
 type WeatherController struct {
+	Client *client.APIClient
+}
+
+func NewWeatherController(c *client.APIClient) *WeatherController {
+	return &WeatherController{Client: c}
 }
 
 func (wc *WeatherController) ShowWeatherPage(w http.ResponseWriter, req *http.Request) {
@@ -28,6 +35,18 @@ func (wc *WeatherController) GetWeatherForecast(w http.ResponseWriter, req *http
 	})
 }
 
-//func FetchForecast(url string) ([]byte, error) {
-//	client := models.NewAPIClient()
-//}
+func (wc *WeatherController) FetchAndParseWeatherResponse(city string) (*models.Forecast, error) {
+	data, err := wc.Client.FetchForecast(city)
+	fmt.Println(data) //debug
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch forecast: %w", err)
+	}
+
+	forecast, err := models.ParseApiResponse(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse forecast: %w", err)
+	}
+
+	fmt.Println(forecast.List[0].Main.Temp) //for debug
+	return forecast, nil
+}

--- a/go/handlers/weather.go
+++ b/go/handlers/weather.go
@@ -29,9 +29,21 @@ func (wc *WeatherController) ShowWeatherPage(w http.ResponseWriter, req *http.Re
 func (wc *WeatherController) GetWeatherForecast(w http.ResponseWriter, req *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
+	forecast, err := wc.FetchAndParseWeatherResponse("Copenhagen")
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(models.StandardResponse{
+			Data: map[string]interface{}{
+				"error": "failed to fetch weather forecast",
+			},
+		})
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(models.StandardResponse{
-		Data: nil,
+		Data: map[string]interface{}{
+			"data": forecast,
+		},
 	})
 }
 

--- a/go/handlers/weather.go
+++ b/go/handlers/weather.go
@@ -27,3 +27,7 @@ func (wc *WeatherController) GetWeatherForecast(w http.ResponseWriter, req *http
 		Data: nil,
 	})
 }
+
+//func FetchForecast(url string) ([]byte, error) {
+//	client := models.NewAPIClient()
+//}

--- a/go/main.go
+++ b/go/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"DVK-Project/client"
 	"DVK-Project/db"
 	"DVK-Project/handlers"
 	"fmt"
@@ -44,7 +45,8 @@ func main() {
 	r.HandleFunc("/search", sc.ShowSearchResults).Methods("GET")
 	r.HandleFunc("/api/search", sc.SearchAPI).Methods("GET") //returns json
 
-	wc := &handlers.WeatherController{}
+	apiClient := client.NewAPIClient()
+	wc := handlers.NewWeatherController(apiClient)
 	r.HandleFunc("/weather", wc.ShowWeatherPage).Methods("GET")
 	r.HandleFunc("/api/weather", wc.GetWeatherForecast).Methods("GET")
 

--- a/go/models/forecast.go
+++ b/go/models/forecast.go
@@ -14,7 +14,7 @@ type Forecast struct {
 	} `json:"list"`
 }
 
-func ParseForecast(data []byte) (*Forecast, error) {
+func ParseApiResponse(data []byte) (*Forecast, error) {
 	var forecast Forecast
 	err := json.Unmarshal(data, &forecast)
 	if err != nil {

--- a/go/models/forecast.go
+++ b/go/models/forecast.go
@@ -1,5 +1,7 @@
 package models
 
+import "encoding/json"
+
 type Forecast struct {
 	List []struct {
 		DtText string `json:"dt_text"`
@@ -10,4 +12,13 @@ type Forecast struct {
 			Description string `json:"description"`
 		} `json:"weather"`
 	} `json:"list"`
+}
+
+func ParseForecast(data []byte) (*Forecast, error) {
+	var forecast Forecast
+	err := json.Unmarshal(data, &forecast)
+	if err != nil {
+		return nil, err
+	}
+	return &forecast, nil
 }


### PR DESCRIPTION
## Description

This pull request refactors the weather forecast API client code and its integration with the controller. The main changes involve moving the API client implementation from the `models` package to a new dedicated `client` package, improving separation of concerns. The weather controller now uses this external client to fetch and parse weather data, and the API endpoint returns actual forecast data instead of a placeholder. Additionally, parsing logic for the API response is added to the `models` package.

**API Client Refactoring and Integration:**

* Moved the `APIClient` implementation from `go/models/client.go` to a new `go/client/client.go` file, improving code organization and separation of concerns. 
* Updated the weather controller in `go/handlers/weather.go` to depend on the new `client.APIClient`, including a constructor for dependency injection. 
* Changed the main application setup in `go/main.go` to instantiate and inject the new API client into the weather controller. 

**Weather Forecast Endpoint Improvements:**

* Modified the `/api/weather` endpoint to fetch and parse actual weather forecast data for Copenhagen, returning it in the API response instead of a placeholder. Added error handling for failed fetches or parsing. 

**API Response Parsing:**

* Added a new `ParseApiResponse` function to `go/models/forecast.go` for unmarshalling API responses into the `Forecast` struct. 

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas