### PR TITLE
Bug fix and improvement of API integration

### DIFF
--- a/go/handlers/weather.go
+++ b/go/handlers/weather.go
@@ -33,23 +33,18 @@ func (wc *WeatherController) GetWeatherForecast(w http.ResponseWriter, req *http
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(models.StandardResponse{
-			Data: map[string]interface{}{
-				"error": "failed to fetch weather forecast",
-			},
+			Data: "failed to fetch weather forecast",
 		})
 		return
 	}
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(models.StandardResponse{
-		Data: map[string]interface{}{
-			"data": forecast,
-		},
+		Data: forecast,
 	})
 }
 
 func (wc *WeatherController) FetchAndParseWeatherResponse(city string) (*models.Forecast, error) {
 	data, err := wc.Client.FetchForecast(city)
-	fmt.Println(data) //debug
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch forecast: %w", err)
 	}

--- a/go/models/forecast.go
+++ b/go/models/forecast.go
@@ -4,7 +4,7 @@ import "encoding/json"
 
 type Forecast struct {
 	List []struct {
-		DtText string `json:"dt_text"`
+		DtText string `json:"dt_txt"`
 		Main   struct {
 			Temp float64 `json:"temp"`
 		} `json:"main"`

--- a/go/models/responses.go
+++ b/go/models/responses.go
@@ -16,5 +16,5 @@ type ValidationErrorDetail struct {
 }
 
 type StandardResponse struct {
-	Data map[string]interface{} `json:"data"`
+	Data interface{} `json:"data"`
 }


### PR DESCRIPTION
## Description

**API response format simplification:**

* Changed the `StandardResponse.Data` type from `map[string]interface{}` to `interface{}` in `go/models/responses.go` to allow direct encoding of any response data, including errors and forecast objects.
* Updated the `GetWeatherForecast` method in `go/handlers/weather.go` to return error messages and forecast data directly in the `Data` field, instead of wrapping them in a map.

**Bug fix:**

* Corrected the JSON field tag for `DtText` in the `Forecast` struct from `dt_text` to `dt_txt` in `go/models/forecast.go` to match the actual API response format.


## Type of change



- [ ] Bug fix (non-breaking change which fixes an issue)

