### PR TITLE
Swagger docs for weather

### DIFF
--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -165,6 +165,47 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/weather": {
+            "get": {
+                "description": "Get weather forecast (temperature, conditions) for 5 days in Copenhagen",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "weather"
+                ],
+                "summary": "Get weather forecast",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/models.StandardResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/models.Forecast"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/login": {
             "get": {
                 "description": "Displays the login page",
@@ -236,6 +277,32 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/weather": {
+            "get": {
+                "description": "Show the weather page.",
+                "produces": [
+                    "text/html"
+                ],
+                "tags": [
+                    "weather"
+                ],
+                "summary": "Serve weather page",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Template not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -287,6 +354,41 @@ const docTemplate = `{
                 }
             }
         },
+        "models.Forecast": {
+            "type": "object",
+            "properties": {
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "dt_txt": {
+                                "type": "string"
+                            },
+                            "main": {
+                                "type": "object",
+                                "properties": {
+                                    "temp": {
+                                        "type": "number"
+                                    }
+                                }
+                            },
+                            "weather": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "description": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "models.HTTPValidationError": {
             "type": "object",
             "properties": {
@@ -296,6 +398,12 @@ const docTemplate = `{
                         "$ref": "#/definitions/models.ValidationErrorDetail"
                     }
                 }
+            }
+        },
+        "models.StandardResponse": {
+            "type": "object",
+            "properties": {
+                "data": {}
             }
         },
         "models.ValidationErrorDetail": {

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -154,6 +154,47 @@
                 }
             }
         },
+        "/api/weather": {
+            "get": {
+                "description": "Get weather forecast (temperature, conditions) for 5 days in Copenhagen",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "weather"
+                ],
+                "summary": "Get weather forecast",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/models.StandardResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/models.Forecast"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/login": {
             "get": {
                 "description": "Displays the login page",
@@ -225,6 +266,32 @@
                     }
                 }
             }
+        },
+        "/weather": {
+            "get": {
+                "description": "Show the weather page.",
+                "produces": [
+                    "text/html"
+                ],
+                "tags": [
+                    "weather"
+                ],
+                "summary": "Serve weather page",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Template not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -276,6 +343,41 @@
                 }
             }
         },
+        "models.Forecast": {
+            "type": "object",
+            "properties": {
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "dt_txt": {
+                                "type": "string"
+                            },
+                            "main": {
+                                "type": "object",
+                                "properties": {
+                                    "temp": {
+                                        "type": "number"
+                                    }
+                                }
+                            },
+                            "weather": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "description": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "models.HTTPValidationError": {
             "type": "object",
             "properties": {
@@ -285,6 +387,12 @@
                         "$ref": "#/definitions/models.ValidationErrorDetail"
                     }
                 }
+            }
+        },
+        "models.StandardResponse": {
+            "type": "object",
+            "properties": {
+                "data": {}
             }
         },
         "models.ValidationErrorDetail": {

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -30,12 +30,38 @@ definitions:
       statusCode:
         type: integer
     type: object
+  models.Forecast:
+    properties:
+      list:
+        items:
+          properties:
+            dt_txt:
+              type: string
+            main:
+              properties:
+                temp:
+                  type: number
+              type: object
+            weather:
+              items:
+                properties:
+                  description:
+                    type: string
+                type: object
+              type: array
+          type: object
+        type: array
+    type: object
   models.HTTPValidationError:
     properties:
       detail:
         items:
           $ref: '#/definitions/models.ValidationErrorDetail'
         type: array
+    type: object
+  models.StandardResponse:
+    properties:
+      data: {}
     type: object
   models.ValidationErrorDetail:
     properties:
@@ -151,6 +177,30 @@ paths:
       summary: Search pages
       tags:
       - search
+  /api/weather:
+    get:
+      description: Get weather forecast (temperature, conditions) for 5 days in Copenhagen
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/models.StandardResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/models.Forecast'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get weather forecast
+      tags:
+      - weather
   /login:
     get:
       description: Displays the login page
@@ -199,4 +249,21 @@ paths:
       summary: Serve register page
       tags:
       - users
+  /weather:
+    get:
+      description: Show the weather page.
+      produces:
+      - text/html
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: string
+        "404":
+          description: Template not found
+          schema:
+            type: string
+      summary: Serve weather page
+      tags:
+      - weather
 swagger: "2.0"

--- a/go/handlers/weather.go
+++ b/go/handlers/weather.go
@@ -17,6 +17,13 @@ func NewWeatherController(c *client.APIClient) *WeatherController {
 	return &WeatherController{Client: c}
 }
 
+// @Summary Serve weather page
+// @Description Show the weather page.
+// @Tags weather
+// @Produce text/html
+// @Success 200 {string} text/html "HTML of weather forecast page"
+// @Failure 404 {string} string "Template not found"
+// @Router /weather [get]
 func (wc *WeatherController) ShowWeatherPage(w http.ResponseWriter, req *http.Request) {
 	tmpl, _ := template.ParseFiles("templates/weather.html")
 	err := tmpl.Execute(w, nil)
@@ -26,6 +33,13 @@ func (wc *WeatherController) ShowWeatherPage(w http.ResponseWriter, req *http.Re
 	}
 }
 
+// @Summary      Get weather forecast
+// @Description  Get weather forecast (temperature, conditions) for 5 days in Copenhagen
+// @Produce      json
+// @Tags weather
+// @Success      200 {object} models.StandardResponse{data=models.Forecast}
+// @Failure      500 {object} map[string]string "Internal Server Error"
+// @Router       /api/weather [get]
 func (wc *WeatherController) GetWeatherForecast(w http.ResponseWriter, req *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
This pull request adds API documentation and endpoint definitions for weather-related features, including a new `/api/weather` endpoint for fetching weather forecasts and a `/weather` endpoint for serving the weather page. It also introduces new data models to describe the forecast response format. These changes ensure that the weather endpoints are well-documented and their responses are clearly defined in Swagger/OpenAPI specifications.

### API Endpoint Documentation

* Added documentation and OpenAPI/Swagger definitions for the new `/api/weather` endpoint, which provides a 5-day weather forecast for Copenhagen in JSON format. The endpoint is tagged as `weather` and specifies success and error response schemas. (`go/docs/docs.go` [[1]](diffhunk://#diff-a16fa234a4accdc65cef8dad3ae2e583bec1ed4c3f3a5cf0a198276668713139R168-R208) `go/docs/swagger.json` [[2]](diffhunk://#diff-02666d14b42d22bcae6f832f69ed09dffcc689856558aeefba67b2b4b702b4fdR157-R197) `go/docs/swagger.yaml` [[3]](diffhunk://#diff-56e03fc6d282bcedddbe133dbc4fea8d092279437700ba4c5e66ede59f26a0ceR180-R203)
* Added documentation and OpenAPI/Swagger definitions for the `/weather` endpoint, which serves the weather page as HTML. It includes response schemas for success (HTML) and template not found errors. (`go/docs/docs.go` [[1]](diffhunk://#diff-a16fa234a4accdc65cef8dad3ae2e583bec1ed4c3f3a5cf0a198276668713139R280-R305) `go/docs/swagger.json` [[2]](diffhunk://#diff-02666d14b42d22bcae6f832f69ed09dffcc689856558aeefba67b2b4b702b4fdR269-R294) `go/docs/swagger.yaml` [[3]](diffhunk://#diff-56e03fc6d282bcedddbe133dbc4fea8d092279437700ba4c5e66ede59f26a0ceR252-R268)

### Data Model Definitions

* Introduced the `models.Forecast` object schema to describe the structure of the weather forecast data, including date/time, temperature, and weather conditions. (`go/docs/docs.go` [[1]](diffhunk://#diff-a16fa234a4accdc65cef8dad3ae2e583bec1ed4c3f3a5cf0a198276668713139R357-R391) `go/docs/swagger.json` [[2]](diffhunk://#diff-02666d14b42d22bcae6f832f69ed09dffcc689856558aeefba67b2b4b702b4fdR346-R380) `go/docs/swagger.yaml` [[3]](diffhunk://#diff-56e03fc6d282bcedddbe133dbc4fea8d092279437700ba4c5e66ede59f26a0ceR33-R65)
* Added the `models.StandardResponse` object schema to standardize API responses, wrapping the forecast data. (`go/docs/docs.go` [[1]](diffhunk://#diff-a16fa234a4accdc65cef8dad3ae2e583bec1ed4c3f3a5cf0a198276668713139R403-R408) `go/docs/swagger.json` [[2]](diffhunk://#diff-02666d14b42d22bcae6f832f69ed09dffcc689856558aeefba67b2b4b702b4fdR392-R397) `go/docs/swagger.yaml` [[3]](diffhunk://#diff-56e03fc6d282bcedddbe133dbc4fea8d092279437700ba4c5e66ede59f26a0ceR33-R65)

### Controller Documentation

* Added Swagger annotations to the `ShowWeatherPage` and `GetWeatherForecast` controller methods to generate API documentation directly from code comments, ensuring consistency between implementation and documentation. (`go/handlers/weather.go` [[1]](diffhunk://#diff-1963e004a4325c83c34a323fbfaa55b621d4ee5fab734192b38f3166aed9f7adR20-R26) [[2]](diffhunk://#diff-1963e004a4325c83c34a323fbfaa55b621d4ee5fab734192b38f3166aed9f7adR36-R42)