### PR TITLE
fix swagger for login

### DIFF
--- a/go/handlers/login.go
+++ b/go/handlers/login.go
@@ -39,14 +39,14 @@ func (lh *LoginHandler) ShowLogin(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Login authenticates a user with email and password.
+// Login authenticates a user with username and password.
 // @Summary Login
-// @Description Authenticates a user using email and password
+// @Description Authenticates a user using username and password
 // @Tags users
 // @Accept application/x-www-form-urlencoded
 // @Produce application/json
-// @Param email formData string true "User email"
-// @Param password formData string true "User password"
+// @Param username formData string true "Username"
+// @Param password formData string true "Password"
 // @Success 200 {object} models.AuthResponse "Successful registration"
 // @Failure 422 {object} models.HTTPValidationError "Validation error"
 // @Router /api/login [post]


### PR DESCRIPTION
This pull request updates the login handler documentation to clarify that authentication is now performed using a username instead of an email address. The changes are focused on improving API documentation for the login endpoint.

API documentation improvements:

* Changed references in the login handler comments and Swagger annotations from "email" to "username" to accurately reflect the authentication method. (`go/handlers/login.go`)