### PR TITLE
Update health check endpoint port to 8080

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -15,4 +15,4 @@ jobs:
         id: health-check
         run: |
           echo "Testing health check on branch: ${{ github.ref_name }}"
-          curl -f --max-time 30 http://${{ secrets.VM_HOST }}/api/health || (echo "App health check failed!" && exit 1)
+          curl -f --max-time 30 http://${{ secrets.VM_HOST }}:8080/api/health || (echo "App health check failed!" && exit 1)


### PR DESCRIPTION
This pull request makes a small update to the health check workflow by specifying port 8080 in the health check URL. This ensures that the health check targets the correct service port.

* Updated the health check command in `.github/workflows/health.yml` to use port 8080 when checking the application's health endpoint.