### PR TITLE
Corrected path in nginx dockerfile

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,2 +1,2 @@
 FROM nginx:latest
-COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
This pull request makes a minor adjustment to the `nginx/Dockerfile` to correct the path used when copying the Nginx configuration file. The updated path ensures the correct file is included in the Docker image.