### PR TITLE
Corrected path in nginx dockerfile

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,2 +1,2 @@
 FROM nginx:latest
-COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
This pull request makes a small update to the `nginx/Dockerfile`, correcting the path used when copying the Nginx configuration file. The change ensures that `nginx.conf` is copied from the correct location.