### PR TITLE
Unit test of search.go that passes

### DIFF
--- a/go/db/page_repository_interface.go
+++ b/go/db/page_repository_interface.go
@@ -1,0 +1,5 @@
+package db
+
+type PageRepoInterface interface {
+	FindSearchResults(searchStr, language string) ([]Result, error)
+}

--- a/go/handlers/search.go
+++ b/go/handlers/search.go
@@ -9,7 +9,9 @@ import (
 )
 
 type SearchController struct {
-	PageRepository *db.PageRepository
+	//PageRepository *db.PageRepository
+	PageRepository db.PageRepoInterface
+	RenderTemplate func(w http.ResponseWriter, r *http.Request, filename string, data interface{})
 }
 
 // ### Page Templating ###
@@ -18,7 +20,7 @@ func (sc *SearchController) ShowSearchResults(w http.ResponseWriter, r *http.Req
 	language := r.FormValue("language")
 
 	if searchStr == "" { //trigger 'No results' block in html.
-		renderTemplate(w, r, "search.html", nil)
+		sc.RenderTemplate(w, r, "search.html", nil)
 		return
 	}
 
@@ -35,7 +37,8 @@ func (sc *SearchController) ShowSearchResults(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	renderTemplate(w, r, "search.html", results)
+	//renderTemplate(w, r, "search.html", results)
+	sc.RenderTemplate(w, r, "search.html", results)
 }
 
 // SearchAPI godoc

--- a/go/handlers/search_test.go
+++ b/go/handlers/search_test.go
@@ -1,0 +1,86 @@
+// search_test.go
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"DVK-Project/db"
+)
+
+// Mock repository
+type MockPageRepo struct{}
+
+func (m *MockPageRepo) FindSearchResults(searchStr string, language string) ([]db.Result, error) {
+	if searchStr == "error" {
+		return nil, errors.New("mock DB error")
+	}
+	return []db.Result{
+		{Title: "Test Page", Url: "/test", Content: "Some content", Language: language},
+	}, nil
+}
+
+func TestShowSearchResults(t *testing.T) {
+	tests := []struct {
+		name           string
+		query          string
+		language       string
+		expectContains string
+		statusCode     int
+	}{
+		{
+			name:           "Empty query triggers no results",
+			query:          "",
+			language:       "",
+			expectContains: "No results",
+			statusCode:     http.StatusOK,
+		},
+		{
+			name:           "Normal query returns result",
+			query:          "test",
+			language:       "en",
+			expectContains: "Test Page",
+			statusCode:     http.StatusOK,
+		},
+		{
+			name:           "Database error returns 500",
+			query:          "error",
+			language:       "",
+			expectContains: "Database error",
+			statusCode:     http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := &SearchController{
+				PageRepository: &MockPageRepo{},
+				RenderTemplate: func(w http.ResponseWriter, r *http.Request, filename string, data interface{}) {
+					if data == nil {
+						w.Write([]byte("No results"))
+					} else {
+						w.Write([]byte("Test Page"))
+					}
+				},
+			}
+
+			req := httptest.NewRequest("GET", "/search?q="+tt.query+"&language="+tt.language, nil)
+			w := httptest.NewRecorder()
+
+			sc.ShowSearchResults(w, req)
+
+			resp := w.Result()
+			body := w.Body.String()
+
+			if resp.StatusCode != tt.statusCode {
+				t.Errorf("expected status %d, got %d", tt.statusCode, resp.StatusCode)
+			}
+			if !strings.Contains(body, tt.expectContains) {
+				t.Errorf("expected body to contain %q, got %q", tt.expectContains, body)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

I hate Go testing. search_test.go has to be in /handlers in order to access unexported functions like renderTemplate.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
