### PR TITLE
Refactor-move prometheus from main to metrics.go

### DIFF
--- a/go/metrics/metrics.go
+++ b/go/metrics/metrics.go
@@ -1,0 +1,73 @@
+package metrics
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	HTTPRequestsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "whoknows_http_requests_total",
+			Help: "Total number of HTTP requests",
+		},
+		[]string{"method", "endpoint", "status"},
+	)
+
+	HTTPRequestDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "whoknows_http_request_duration_seconds",
+			Help:    "Duration of HTTP requests in seconds",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"method", "endpoint"},
+	)
+
+	ActiveUsers = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "whoknows_active_users",
+		Help: "Number of currently active users",
+	})
+)
+
+// responseWriter wraps http.ResponseWriter to capture status code
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+// Middleware returns a metrics middleware to measure requests
+func Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+
+		next.ServeHTTP(rw, r)
+
+		duration := time.Since(start).Seconds()
+
+		route := mux.CurrentRoute(r)
+		path, _ := route.GetPathTemplate()
+		if path == "" {
+			path = r.URL.Path
+		}
+
+		HTTPRequestsTotal.WithLabelValues(r.Method, path, strconv.Itoa(rw.statusCode)).Inc()
+		HTTPRequestDuration.WithLabelValues(r.Method, path).Observe(duration)
+	})
+}
+
+// Handler returns the /metrics http.Handler
+func Handler() http.Handler {
+	return promhttp.Handler()
+}


### PR DESCRIPTION
This pull request refactors the application's Prometheus metrics integration by moving all metrics-related logic into a dedicated `metrics` package. This change improves code organization, separation of concerns, and maintainability. The main application code (`go/main.go`) is simplified by delegating metrics handling to the new package.

**Metrics refactoring and code organization:**

* All metrics definitions, the middleware for collecting metrics, and the `/metrics` endpoint handler have been moved from `go/main.go` to a new file, `go/metrics/metrics.go`, encapsulated in a new `metrics` package. [[1]](diffhunk://#diff-a240b23c8c4a5b71406f4393240035163be74a3840d5fdaa4b2a993872e8cf65R7-L62) [[2]](diffhunk://#diff-8439ef2cb3edf0b96030e3cf5abdf11a74ce79d69e25263d59b6334170da721fR1-R73)
* The main application now imports and uses `metrics.Middleware` and `metrics.Handler()` instead of defining and registering metrics logic directly. [[1]](diffhunk://#diff-a240b23c8c4a5b71406f4393240035163be74a3840d5fdaa4b2a993872e8cf65L73-R26) [[2]](diffhunk://#diff-a240b23c8c4a5b71406f4393240035163be74a3840d5fdaa4b2a993872e8cf65L104-R57)

**Prometheus metrics improvements:**

* Metrics names have been prefixed with `whoknows_` for better namespace clarity in Prometheus.
* The metrics middleware and handler are now reusable and easier to test or extend, thanks to their encapsulation in a dedicated package.

- [ ] Bug fix (non-breaking change which fixes an issue)
