### PR TITLE
Updated loki config in compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -42,9 +42,9 @@ services:
       - "3100:3100"
     volumes:
       - ./logging/loki-config.yaml:/etc/loki/local-config.yaml
-      - loki-data:/loki
       - ./logging/loki-chunks:/loki/chunks
       - ./logging/loki-rules:/loki/rules
+      - ./logging/loki-wal:/loki/wal
     command: -config.file=/etc/loki/local-config.yaml
     networks:
       - webnet


### PR DESCRIPTION
This pull request makes a small update to the Loki service configuration in `docker-compose.prod.yml` by adjusting the mounted volumes. The change removes the use of the `loki-data` named volume and instead mounts a new directory for Loki's WAL (Write-Ahead Log) data.

- Docker Compose Loki service: Removed the `loki-data` named volume and added a bind mount for `./logging/loki-wal` to `/loki/wal` to explicitly manage WAL data storage.