### PR TITLE
Add remote write to prometheus

### DIFF
--- a/logging/prometheus.yml
+++ b/logging/prometheus.yml
@@ -16,3 +16,6 @@ scrape_configs:
     static_configs:
       - targets: ['alloy:12345']
 
+remote_write:
+  - url: http://alloy:12345/api/v1/push
+


### PR DESCRIPTION
This pull request updates the Prometheus configuration to enable remote writing of metrics data. The main change is the addition of a `remote_write` section, which configures Prometheus to send metrics to an external endpoint.

Prometheus remote write configuration:

* Added a `remote_write` section to `logging/prometheus.yml`, specifying an external URL (`http://alloy:12345/api/v1/push`) for pushing metrics data.