### PR TITLE
Add app metrics in alloy

### DIFF
--- a/logging/alloy-config.yaml
+++ b/logging/alloy-config.yaml
@@ -106,3 +106,12 @@ prometheus.scrape "system" {
   forward_to = [prometheus.remote_write.default.receiver]
   scrape_interval = "15s"
 }
+
+// App metrics
+prometheus.scrape "whoknows_app" {
+  targets = [
+    { __address__ = "whoknows-prod:8080", job = "whoknows" }
+  ]
+  scrape_interval = "15s"
+  forward_to = [prometheus.remote_write.default.receiver]
+}

--- a/logging/prometheus.yml
+++ b/logging/prometheus.yml
@@ -13,9 +13,8 @@ scrape_configs:
       - targets: ['loki:3100']
 
   - job_name: 'alloy'
+    metrics_path: /metrics
     static_configs:
       - targets: ['alloy:12345']
 
-remote_write:
-  - url: http://alloy:12345/api/v1/push
 


### PR DESCRIPTION
This pull request adds support for scraping application metrics from the `whoknows` service and makes a minor configuration adjustment for the Prometheus scrape job targeting Alloy. The main changes are as follows:

**Prometheus Scraping Configuration:**

* Added a new `prometheus.scrape` block in `logging/alloy-config.yaml` to scrape metrics from the `whoknows` application at `whoknows-prod:8080` every 15 seconds and forward them to the remote write receiver.

**Prometheus Job Configuration:**

* Added an explicit `metrics_path: /metrics` to the `alloy` job in `logging/prometheus.yml` for clarity and correctness.