### PR TITLE
alloy wants a comma

### DIFF
--- a/logging/alloy-config.yaml
+++ b/logging/alloy-config.yaml
@@ -102,7 +102,7 @@ prometheus.scrape "system" {
 // App metrics
 prometheus.scrape "whoknows_app" {
   targets = [
-    { __address__ = "whoknows-prod:8080", job = "whoknows" }
+    { __address__ = "whoknows-prod:8080", job = "whoknows", }
   ]
   scrape_interval = "15s"
   forward_to = [prometheus.remote_write.default.receiver]


### PR DESCRIPTION
This pull request makes a minor formatting change to the `logging/alloy-config.yaml` file by adding a trailing comma to the `targets` entry for the `whoknows_app` Prometheus scrape configuration.