### PR TITLE
Alloy doesnt want a comma after all

### DIFF
--- a/logging/alloy-config.yaml
+++ b/logging/alloy-config.yaml
@@ -102,8 +102,12 @@ prometheus.scrape "system" {
 // App metrics
 prometheus.scrape "whoknows_app" {
   targets = [
-    { __address__ = "whoknows-prod:8080", job = "whoknows", }
+    {
+      __address__ = "whoknows-prod:8080"
+      job         = "whoknows"
+    }
   ]
+  
   scrape_interval = "15s"
   forward_to = [prometheus.remote_write.default.receiver]
 }


### PR DESCRIPTION
This pull request makes a minor formatting adjustment to the `logging/alloy-config.yaml` file, improving the readability of the `prometheus.scrape "whoknows_app"` configuration block.

- Reformatted the entries in the `targets` list to use multi-line style for better clarity and consistency.
