### PR TITLE
Trying to fix alloy

### DIFF
--- a/logging/alloy-config.yaml
+++ b/logging/alloy-config.yaml
@@ -101,13 +101,8 @@ prometheus.scrape "system" {
 
 // App metrics
 prometheus.scrape "whoknows_app" {
-  targets = [
-    {
-      __address__ = "whoknows-prod:8080"
-      job         = "whoknows"
-    }
-  ]
-  
+  targets = ["whoknows-prod:8080"]
+  job_name = "whoknows"
   scrape_interval = "15s"
   forward_to = [prometheus.remote_write.default.receiver]
 }


### PR DESCRIPTION
This pull request makes a small update to the Prometheus scraping configuration for the `whoknows_app` target. The change simplifies the target definition and updates the job configuration to use the `job_name` field.

- Simplified the `targets` definition for the `whoknows_app` scrape job and switched from a target object with a `job` field to a string target with a separate `job_name` field in `logging/alloy-config.yaml`.