### PR TITLE
Add cadvisor

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -105,6 +105,19 @@ services:
       - webnet
     restart: unless-stopped
 
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: cadvisor
+    ports:
+      - "8081:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /sys:/sys:ro
+    networks:
+      - webnet
+    restart: unless-stopped
+
+
   grafana:
     image: grafana/grafana:latest
     container_name: grafana

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -92,6 +92,19 @@ services:
       - webnet
     restart: unless-stopped
 
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: cadvisor
+    ports:
+      - "8081:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    networks:
+      - webnet
+    restart: unless-stopped
+
 
 volumes:
   loki-data:      

--- a/logging/prometheus.yml
+++ b/logging/prometheus.yml
@@ -13,8 +13,11 @@ scrape_configs:
       - targets: ['loki:3100']
 
   - job_name: 'alloy'
-    metrics_path: /metrics
     static_configs:
       - targets: ['alloy:12345']
+
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: [ 'cadvisor:8081' ]
 
 


### PR DESCRIPTION
This pull request introduces cAdvisor into both the development and production Docker Compose environments for container monitoring, and updates the Prometheus configuration to scrape metrics from the new cAdvisor service. These changes enhance observability by enabling container-level metrics collection.

**Monitoring and Observability Enhancements:**

* Added a `cadvisor` service to both `docker-compose.dev.yml` and `docker-compose.prod.yml` for container metrics collection, exposing it on port 8081 and mounting necessary volumes for access to container data. The production configuration includes an additional volume for `/var/lib/docker`. [[1]](diffhunk://#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1R108-R120) [[2]](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3R95-R107)
* Updated `logging/prometheus.yml` to add a new scrape job for `cadvisor` metrics, allowing Prometheus to collect data from the cAdvisor service.