### PR TITLE
Remove services from compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,32 +32,6 @@ services:
     networks:
       - webnet
 
-  loki:
-    image: grafana/loki:latest
-    container_name: loki
-    user: "10001:10001"
-    ports:
-      - "3100:3100"
-    volumes:
-      - ./logging/loki-data:/loki
-    command: -config.file=/etc/loki/local-config.yaml
-    networks:
-      - webnet
-    restart: unless-stopped
-
-  prometheus:
-    image: prom/prometheus:latest
-    container_name: prometheus
-    user: "65534:65534" 
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./logging/prometheus.yml:/etc/prometheus/prometheus.yml
-      - prometheus-data:/prometheus
-    networks:
-      - webnet
-    restart: unless-stopped
-
   node-exporter:
     image: prom/node-exporter:latest
     container_name: node-exporter
@@ -86,6 +60,7 @@ services:
       - ./logging/alloy-config.yaml:/etc/alloy/config.alloy
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/log:/var/log:ro
+      - /var/lib/docker:/var/lib/docker:ro
       - alloy-data:/var/lib/alloy
     command: run --server.http.listen-addr=0.0.0.0:12345 /etc/alloy/config.alloy
     networks:
@@ -108,8 +83,6 @@ services:
       - webnet
 
 volumes:
-  loki-data:      
-  prometheus-data:
   alloy-data:
 
 networks:


### PR DESCRIPTION
## Description

This pull request updates the production Docker Compose configuration by removing the Loki and Prometheus services, and making adjustments to the Alloy service and associated volumes. These changes streamline the monitoring and logging stack by consolidating services.

**Service removals:**

* Removed the `loki` service from the `docker-compose.prod.yml` file, including its image, ports, volumes, and network configuration.
* Removed the `prometheus` service from the `docker-compose.prod.yml` file, including its image, ports, volumes, and network configuration.

**Volume and configuration updates:**

* Removed the `loki-data` and `prometheus-data` volumes from the `volumes` section, as they are no longer needed.
* Added a read-only mount of `/var/lib/docker` to the `alloy` service to enhance its access to Docker-related metrics or logs.
- [ ] Bug fix (non-breaking change which fixes an issue)

